### PR TITLE
feat: [#14] reading-banner の color-mix フォールバック

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -344,9 +344,25 @@ body {
   margin: 0 0 0.5rem;
   border: 1px solid var(--danger);
   border-radius: var(--radius);
-  background: color-mix(in srgb, var(--danger) 12%, var(--surface));
+  background: #f4e0e4;
   font-size: 0.85rem;
   line-height: 1.45;
+}
+
+html[data-theme='dark'] .reading-banner {
+  background: #35232b;
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='system'] .reading-banner {
+    background: #35232b;
+  }
+}
+
+@supports (background: color-mix(in srgb, red 12%, blue)) {
+  .reading-banner {
+    background: color-mix(in srgb, var(--danger) 12%, var(--surface));
+  }
 }
 
 .reading-banner__text {


### PR DESCRIPTION
## 概要

`color-mix` 未対応ブラウザでも読書バナー背景が無効にならないよう、`@supports` で機能提供を判定しつつ、ライト／ダークそれぞれに近い単色フォールバックを用意しました。対応ブラウザでは従来どおり CSS 変数ベースの `color-mix` が使われます。

Closes #14

## 変更ファイルとその概要

```
src/
└── ✅ index.css
    - `.reading-banner` に単色フォールバックとテーマ別上書きを追加
    - `@supports (background: color-mix(...))` で既存の mix 背景へフォールバック
```

## テスト内容（参考までに）

- `npm run lint` / `npm run build` 済み。
- ライト／ダーク／システムテーマでバナー背景が破綻しないことを確認してください。

## 関連 issue

Closes #14
