### PR TITLE
feat: [#2] 読書一覧に並び替え（更新日・タイトル）を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,10 @@ import { ReadingListPanel } from './reading/components/ReadingListPanel'
 import { ThemeToggle } from './reading/components/ThemeToggle'
 import { useBooks } from './reading/hooks/useBooks'
 import { filterBooks, type BookFilterValue } from './reading/lib/filterBooks'
+import {
+  sortBooksList,
+  type BookSortOption,
+} from './reading/lib/sortBooks'
 
 const NARROW_MAX = 640
 
@@ -31,15 +35,16 @@ export default function App() {
   const { books, loadCorruption, addBook, updateBook, removeBook, clearLoadCorruption } =
     useBooks()
   const [filter, setFilter] = useState<BookFilterValue>('all')
+  const [sort, setSort] = useState<BookSortOption>('updated-desc')
   const [search, setSearch] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [mobilePanel, setMobilePanel] = useState<MobilePanel>('list')
   const isNarrow = useNarrowView()
 
-  const visibleBooks = useMemo(
-    () => filterBooks(books, filter, search),
-    [books, filter, search],
-  )
+  const visibleBooks = useMemo(() => {
+    const filtered = filterBooks(books, filter, search)
+    return sortBooksList(filtered, sort)
+  }, [books, filter, search, sort])
 
   const selectedBook = useMemo(
     () => (selectedId ? (books.find((b) => b.id === selectedId) ?? null) : null),
@@ -96,6 +101,8 @@ export default function App() {
             visibleBooks={visibleBooks}
             filter={filter}
             onFilterChange={setFilter}
+            sort={sort}
+            onSortChange={setSort}
             search={search}
             onSearchChange={setSearch}
             selectedId={selectedId}

--- a/src/index.css
+++ b/src/index.css
@@ -409,6 +409,37 @@ html[data-theme='dark'] .reading-banner {
   color: var(--text-heading);
 }
 
+.reading-sort {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.reading-sort__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.reading-sort__select {
+  width: 100%;
+  font: inherit;
+  color: var(--text-heading);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 0.45rem 0.65rem;
+}
+
+.reading-sort__select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+
 .reading-search__wrap {
   margin: 0;
   display: flex;

--- a/src/reading/components/BookFilterBar.tsx
+++ b/src/reading/components/BookFilterBar.tsx
@@ -1,9 +1,12 @@
 import type { BookFilterValue } from '../lib/filterBooks'
+import type { BookSortOption } from '../lib/sortBooks'
 import { BOOK_STATUS_LABEL } from '../statusLabels'
 
 type BookFilterBarProps = {
   filter: BookFilterValue
   onFilterChange: (v: BookFilterValue) => void
+  sort: BookSortOption
+  onSortChange: (v: BookSortOption) => void
   search: string
   onSearchChange: (v: string) => void
   searchId: string
@@ -16,9 +19,18 @@ const FILTERS: { value: BookFilterValue; label: string }[] = [
   { value: 'finished', label: BOOK_STATUS_LABEL.finished },
 ]
 
+const SORTS: { value: BookSortOption; label: string }[] = [
+  { value: 'updated-desc', label: '更新日（新しい順）' },
+  { value: 'updated-asc', label: '更新日（古い順）' },
+  { value: 'title-asc', label: 'タイトル（あいうえお順）' },
+  { value: 'title-desc', label: 'タイトル（逆順）' },
+]
+
 export function BookFilterBar({
   filter,
   onFilterChange,
+  sort,
+  onSortChange,
   search,
   onSearchChange,
   searchId,
@@ -51,6 +63,24 @@ export function BookFilterBar({
           })}
         </div>
       </fieldset>
+      <p className="reading-sort">
+        <label className="reading-sort__label" htmlFor="reading-book-sort">
+          並び順
+        </label>
+        <select
+          id="reading-book-sort"
+          className="reading-sort__select"
+          value={sort}
+          onChange={(e) => onSortChange(e.target.value as BookSortOption)}
+          aria-label="一覧の並び順"
+        >
+          {SORTS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </p>
       <p className="reading-search__wrap">
         <label className="reading-search__label" htmlFor={searchId}>
           タイトル検索

--- a/src/reading/components/ReadingListPanel.tsx
+++ b/src/reading/components/ReadingListPanel.tsx
@@ -1,6 +1,7 @@
 import { useId } from 'react'
 import type { Book } from '../types/book'
 import type { BookFilterValue } from '../lib/filterBooks'
+import type { BookSortOption } from '../lib/sortBooks'
 import { BookFilterBar } from './BookFilterBar'
 import { BookListRow } from './BookListRow'
 
@@ -9,6 +10,8 @@ type ReadingListPanelProps = {
   visibleBooks: Book[]
   filter: BookFilterValue
   onFilterChange: (v: BookFilterValue) => void
+  sort: BookSortOption
+  onSortChange: (v: BookSortOption) => void
   search: string
   onSearchChange: (v: string) => void
   selectedId: string | null
@@ -23,6 +26,8 @@ export function ReadingListPanel({
   visibleBooks,
   filter,
   onFilterChange,
+  sort,
+  onSortChange,
   search,
   onSearchChange,
   selectedId,
@@ -59,6 +64,8 @@ export function ReadingListPanel({
       <BookFilterBar
         filter={filter}
         onFilterChange={onFilterChange}
+        sort={sort}
+        onSortChange={onSortChange}
         search={search}
         onSearchChange={onSearchChange}
         searchId={searchId}

--- a/src/reading/lib/sortBooks.ts
+++ b/src/reading/lib/sortBooks.ts
@@ -1,0 +1,23 @@
+import type { Book } from '../types/book'
+
+export type BookSortOption = 'updated-desc' | 'updated-asc' | 'title-asc' | 'title-desc'
+
+function cmpTitleJa(a: Book, b: Book) {
+  return a.title.trim().localeCompare(b.title.trim(), 'ja')
+}
+
+export function sortBooksList(books: Book[], sort: BookSortOption): Book[] {
+  const next = [...books]
+  switch (sort) {
+    case 'updated-desc':
+      return next.sort((a, b) => b.updatedAt - a.updatedAt)
+    case 'updated-asc':
+      return next.sort((a, b) => a.updatedAt - b.updatedAt)
+    case 'title-asc':
+      return next.sort(cmpTitleJa)
+    case 'title-desc':
+      return next.sort((a, b) => cmpTitleJa(b, a))
+    default:
+      return next
+  }
+}


### PR DESCRIPTION
## 概要

一覧の表示順を、更新日（新しい／古い）とタイトル（あいうえお／逆）から選べるようにしました。フィルタ・検索後の結果に対して並び替えが適用されます。

Closes #2

## 変更ファイルとその概要

```
src/
├── ✅ App.tsx
│   - 並び順 state と filter + sort の合成
├── ✅ index.css
│   - 並び順セレクト用スタイル（`.reading-sort`）
├── reading/components/
│   ├── ✅ BookFilterBar.tsx
│   │   - 並び順ドロップダウン
│   └── ✅ ReadingListPanel.tsx
│       - sort / onSort  props の受け渡し
└── reading/lib/
    └── ✅ sortBooks.ts（新規）
        - `BookSortOption` と `sortBooksList`
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功
- 手動: 並び順変更で一覧の順序が期待どおり変わること

## 関連 issue

close #2
