### PR TITLE
feat: [#15] 読書状態バッジの色分けとコントラスト改善

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,15 @@
   --danger-hover: #a8222f;
   --item-hover: #f0ecf5;
   --item-active: #e8e0f5;
+  --status-unread-bg: #ebe7f0;
+  --status-unread-fg: #3f3648;
+  --status-unread-border: #c9c0d8;
+  --status-reading-bg: #ebe4ff;
+  --status-reading-fg: #4a2d9e;
+  --status-reading-border: #c4b0f0;
+  --status-finished-bg: #e2f4ec;
+  --status-finished-fg: #1a5a42;
+  --status-finished-border: #9fd4bc;
   --shadow: 0 1px 2px rgba(20, 17, 24, 0.06);
   --radius: 10px;
   --sans: system-ui, 'Segoe UI', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
@@ -36,6 +45,15 @@ html[data-theme='dark'] {
   --danger-hover: #f5a0a5;
   --item-hover: #25212c;
   --item-active: #302a3d;
+  --status-unread-bg: #2c2835;
+  --status-unread-fg: #d8d2e2;
+  --status-unread-border: #4a4358;
+  --status-reading-bg: #352a4d;
+  --status-reading-fg: #d4c4ff;
+  --status-reading-border: #6b52a8;
+  --status-finished-bg: #1e3d32;
+  --status-finished-fg: #a8e8cc;
+  --status-finished-border: #3d8f6a;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
@@ -53,6 +71,15 @@ html[data-theme='dark'] {
     --danger-hover: #f5a0a5;
     --item-hover: #25212c;
     --item-active: #302a3d;
+    --status-unread-bg: #2c2835;
+    --status-unread-fg: #d8d2e2;
+    --status-unread-border: #4a4358;
+    --status-reading-bg: #352a4d;
+    --status-reading-fg: #d4c4ff;
+    --status-reading-border: #6b52a8;
+    --status-finished-bg: #1e3d32;
+    --status-finished-fg: #a8e8cc;
+    --status-finished-border: #3d8f6a;
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
   }
 }
@@ -505,8 +532,25 @@ html[data-theme='dark'] .reading-banner {
   font-weight: 600;
   padding: 0.1rem 0.35rem;
   border-radius: 4px;
-  border: 1px solid var(--border);
-  color: var(--text-muted);
+  border: 1px solid transparent;
+}
+
+.reading-list__status--unread {
+  background: var(--status-unread-bg);
+  color: var(--status-unread-fg);
+  border-color: var(--status-unread-border);
+}
+
+.reading-list__status--reading {
+  background: var(--status-reading-bg);
+  color: var(--status-reading-fg);
+  border-color: var(--status-reading-border);
+}
+
+.reading-list__status--finished {
+  background: var(--status-finished-bg);
+  color: var(--status-finished-fg);
+  border-color: var(--status-finished-border);
 }
 
 .reading-list__dates {

--- a/src/reading/components/BookListRow.tsx
+++ b/src/reading/components/BookListRow.tsx
@@ -50,7 +50,7 @@ export function BookListRow({ book, selected, onSelect, idPrefix }: BookListRowP
             {displayTitle(book.title)}
           </span>
           <span
-            className="reading-list__status"
+            className={`reading-list__status reading-list__status--${book.status}`}
             aria-label={`状態: ${BOOK_STATUS_LABEL[book.status]}`}
           >
             {BOOK_STATUS_LABEL[book.status]}


### PR DESCRIPTION
## 概要

一覧の読書状態バッジ（未読／読書中／読了）を、状態ごとに背景色・文字色・ボーダーを分けました。ライト／ダーク（手動・システム）いずれでもラベル文字が読みやすいトーンにしています。色だけに依存せず、従来どおりテキストラベルと `aria-label` を維持しています。

Closes #15

## 変更ファイルとその概要

```
src/
├── ✅ index.css
│   - `--status-*` トークン（:root / dark / system dark）
│   - `.reading-list__status--unread|reading|finished`
└── reading/components/
    └── ✅ BookListRow.tsx
        - 状態に応じた BEM 修飾クラス
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功
- 手動: テーマ切替で各バッジが判別しやすいこと

## 関連 issue

close #15
