### PR TITLE
feat: [#16] 本の削除確認をモーダルダイアログに変更

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -626,3 +626,53 @@ html[data-theme='dark'] .reading-banner {
   line-height: 1.45;
   font-size: 0.95rem;
 }
+
+.confirm-dialog {
+  padding: 0;
+  border: none;
+  max-width: calc(100vw - 2rem);
+  background: transparent;
+}
+
+.confirm-dialog::backdrop {
+  background: rgba(20, 17, 24, 0.45);
+}
+
+html[data-theme='dark'] .confirm-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='system'] .confirm-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.55);
+  }
+}
+
+.confirm-dialog__panel {
+  padding: 1.15rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  min-width: min(18rem, calc(100vw - 2rem));
+}
+
+.confirm-dialog__title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--text-heading);
+}
+
+.confirm-dialog__message {
+  margin: 0 0 1rem;
+  color: var(--text);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/src/reading/components/BookForm.tsx
+++ b/src/reading/components/BookForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { Book, BookStatus } from '../types/book'
 import { BOOK_STATUS_LABEL } from '../statusLabels'
+import { ConfirmDialog } from './ConfirmDialog'
 
 type BookFormProps = {
   book: Book | null
@@ -20,6 +21,7 @@ export function BookForm({
   showBackButton,
 }: BookFormProps) {
   const [titleError, setTitleError] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   if (!book) {
     return (
@@ -34,10 +36,17 @@ export function BookForm({
   const id = book.id
   const canSave = book.title.trim().length > 0
 
-  const handleDelete = () => {
-    if (window.confirm('この本の記録を削除します。よろしいですか？')) {
-      onDelete(id)
-    }
+  const handleDeleteRequest = () => {
+    setDeleteOpen(true)
+  }
+
+  const handleDeleteConfirm = () => {
+    setDeleteOpen(false)
+    onDelete(id)
+  }
+
+  const handleDeleteCancel = () => {
+    setDeleteOpen(false)
   }
 
   const handleSaveClick = () => {
@@ -64,7 +73,7 @@ export function BookForm({
           <button type="button" className="button button--primary" onClick={handleSaveClick}>
             保存
           </button>
-          <button type="button" className="button button--danger" onClick={handleDelete}>
+          <button type="button" className="button button--danger" onClick={handleDeleteRequest}>
             削除
           </button>
         </div>
@@ -157,6 +166,16 @@ export function BookForm({
         onChange={(e) => onPatch(id, { notes: e.target.value })}
         placeholder="感想やメモを自由に"
         rows={12}
+      />
+      <ConfirmDialog
+        open={deleteOpen}
+        title="本の記録を削除"
+        message="この本の記録を削除します。戻すことはできません。"
+        confirmLabel="削除する"
+        cancelLabel="キャンセル"
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+        variant="danger"
       />
     </section>
   )

--- a/src/reading/components/ConfirmDialog.tsx
+++ b/src/reading/components/ConfirmDialog.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react'
+
+type ConfirmDialogProps = {
+  open: boolean
+  title: string
+  message: string
+  confirmLabel: string
+  cancelLabel: string
+  onConfirm: () => void
+  onCancel: () => void
+  /** 危険操作の主ボタンを強調する場合 */
+  variant?: 'danger' | 'default'
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  variant = 'default',
+}: ConfirmDialogProps) {
+  const ref = useRef<HTMLDialogElement>(null)
+  const confirmedRef = useRef(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) {
+      return
+    }
+    const onClose = () => {
+      if (confirmedRef.current) {
+        confirmedRef.current = false
+        return
+      }
+      onCancel()
+    }
+    el.addEventListener('close', onClose)
+    return () => el.removeEventListener('close', onClose)
+  }, [onCancel])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) {
+      return
+    }
+    if (open && !el.open) {
+      el.showModal()
+      return
+    }
+    if (!open && el.open) {
+      el.close()
+    }
+  }, [open])
+
+  const closeDialog = () => {
+    ref.current?.close()
+  }
+
+  const handleConfirm = () => {
+    confirmedRef.current = true
+    onConfirm()
+    closeDialog()
+  }
+
+  return (
+    <dialog ref={ref} className="confirm-dialog" aria-labelledby="confirm-dialog-title">
+      <div className="confirm-dialog__panel" role="document">
+        <h2 id="confirm-dialog-title" className="confirm-dialog__title">
+          {title}
+        </h2>
+        <p className="confirm-dialog__message">{message}</p>
+        <div className="confirm-dialog__actions">
+          <button type="button" className="button button--ghost" onClick={closeDialog}>
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={
+              variant === 'danger' ? 'button button--danger' : 'button button--primary'
+            }
+            onClick={handleConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  )
+}


### PR DESCRIPTION
## 概要

`window.confirm` の代わりにネイティブの `<dialog>` を用いた確認モーダルを表示するようにしました。ブラウザのフォーカス管理・ESC での閉じに任せつつ、見出し・本文・主／副ボタンを明示しています。

Closes #16

## 変更ファイルとその概要

```
src/
├── ✅ index.css
│   - `.confirm-dialog` とバックドロップ
└── reading/components/
    ├── ✅ ConfirmDialog.tsx（新規）
    │   - showModal / close と確定時の close イベントの取り扱い
    └── ✅ BookForm.tsx
        - 削除フローをモーダルに差し替え
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功
- 手動: 削除→キャンセル／確定、ESC、フォーカス移動

## 関連 issue

close #16
