### PR TITLE
feat: [#17] 読書一覧のキーボードナビ（矢印・Home/End）

### DIFF
--- a/src/reading/components/ReadingListPanel.tsx
+++ b/src/reading/components/ReadingListPanel.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useCallback, useId, useRef, type KeyboardEvent } from 'react'
 import type { Book } from '../types/book'
 import type { BookFilterValue } from '../lib/filterBooks'
 import { BookFilterBar } from './BookFilterBar'
@@ -33,6 +33,57 @@ export function ReadingListPanel({
 }: ReadingListPanelProps) {
   const searchId = useId()
   const listId = useId()
+  const listRef = useRef<HTMLUListElement>(null)
+
+  const handleListKeyDownCapture = useCallback(
+    (e: KeyboardEvent<HTMLUListElement>) => {
+      const target = e.target
+      if (!(target instanceof HTMLButtonElement)) {
+        return
+      }
+      if (!target.classList.contains('reading-list__button')) {
+        return
+      }
+      const root = listRef.current
+      if (!root) {
+        return
+      }
+      const buttons = [
+        ...root.querySelectorAll<HTMLButtonElement>('.reading-list__button'),
+      ]
+      const idx = buttons.indexOf(target)
+      if (idx < 0) {
+        return
+      }
+
+      const moveFocus = (nextIndex: number) => {
+        const i = Math.max(0, Math.min(nextIndex, buttons.length - 1))
+        buttons[i]?.focus()
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          moveFocus(idx + 1)
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          moveFocus(idx - 1)
+          break
+        case 'Home':
+          e.preventDefault()
+          moveFocus(0)
+          break
+        case 'End':
+          e.preventDefault()
+          moveFocus(buttons.length - 1)
+          break
+        default:
+          break
+      }
+    },
+    [],
+  )
 
   return (
     <aside className="reading-sidebar" aria-label="読書の一覧">
@@ -72,7 +123,13 @@ export function ReadingListPanel({
           条件に一致する本がありません。フィルタやタイトル検索を変えてみてください。
         </p>
       ) : (
-        <ul className="reading-list" role="list" aria-label="登録した本">
+        <ul
+          ref={listRef}
+          className="reading-list"
+          role="list"
+          aria-label="登録した本"
+          onKeyDownCapture={handleListKeyDownCapture}
+        >
           {visibleBooks.map((b) => (
             <BookListRow
               key={b.id}


### PR DESCRIPTION
## 概要

一覧の各行ボタンにフォーカスがあるとき、矢印上下・Home・End で前後の行へフォーカスを移動できるようにしました（キャプチャフェーズで `ul` に集約）。

Closes #17

## 変更ファイルとその概要

```
src/reading/components/
└── ✅ ReadingListPanel.tsx
    - `listRef` と `onKeyDownCapture` によるフォーカス移動
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功
- 手動: 一覧行に Tab でフォーカス後、矢印・Home/End

## 関連 issue

close #17
