### PR TITLE
feat: [#18] 検索・フィルタ結果件数の aria-live 通知

### DIFF
--- a/src/reading/components/ReadingListPanel.tsx
+++ b/src/reading/components/ReadingListPanel.tsx
@@ -63,6 +63,13 @@ export function ReadingListPanel({
         onSearchChange={onSearchChange}
         searchId={searchId}
       />
+      {books.length > 0 ? (
+        <p className="reading-assistive" aria-live="polite" aria-atomic="true">
+          {visibleBooks.length === 0
+            ? '条件に一致する本は 0 件です。'
+            : `${visibleBooks.length} 件を表示しています。`}
+        </p>
+      ) : null}
       {books.length === 0 ? (
         <p className="reading-sidebar__empty">
           まだ本が登録されていません。「新規登録」で紙本・電子籍の記録を始められます。


### PR DESCRIPTION
## 概要

登録済みの本があるとき、フィルタ・検索後の表示件数を `aria-live="polite"` でスクリーンリーダーに通知するようにしました（視覚的には既存の `.reading-assistive` で非表示）。

Closes #18

## 変更ファイルとその概要

```
src/reading/components/
└── ✅ ReadingListPanel.tsx
    - 件数メッセージのライブリージョン
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功

## 関連 issue

close #18
