### PR TITLE
feat: [#19] 自動保存の明示と「入力チェック」ボタンへの改称

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -573,6 +573,13 @@ html[data-theme='dark'] .reading-banner {
   font-size: 0.9rem;
 }
 
+.reading-form__hint {
+  margin: 0 0 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
 .reading-form__label {
   font-size: 0.75rem;
   font-weight: 600;

--- a/src/reading/components/BookForm.tsx
+++ b/src/reading/components/BookForm.tsx
@@ -62,16 +62,19 @@ export function BookForm({
         ) : null}
         <div className="reading-form__toolbar-right">
           <button type="button" className="button button--primary" onClick={handleSaveClick}>
-            保存
+            入力チェック
           </button>
           <button type="button" className="button button--danger" onClick={handleDelete}>
             削除
           </button>
         </div>
       </div>
+      <p className="reading-form__hint">
+        編集内容は入力のたびに自動で端末に保存されます（このボタンは必須入力の確認用です）。
+      </p>
       {titleError ? (
         <p className="reading-form__error" role="alert">
-          タイトルは必須です。入力してから保存してください。
+          タイトルは必須です。入力してから入力チェックを押してください。
         </p>
       ) : null}
       <label className="reading-form__label" htmlFor="book-title">


### PR DESCRIPTION
## 概要

編集内容が即時・自動で localStorage に保存されることをツールバー直下のヒントで明示し、主ボタンのラベルを「保存」から「入力チェック」に変更しました。エラー文言も「入力チェック」に合わせています。

Closes #19

## 変更ファイルとその概要

```
src/
├── ✅ index.css
│   - `.reading-form__hint`
└── reading/components/
    └── ✅ BookForm.tsx
        - ボタン文言・説明・エラーメッセージ
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功

## 関連 issue

close #19
