### PR TITLE
fix: [#25] localStorage 保存失敗時の画面上通知と再試行

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function useNarrowView() {
 }
 
 export default function App() {
-  const { books, loadCorruption, addBook, updateBook, removeBook, clearLoadCorruption } =
+  const { books, loadCorruption, saveError, addBook, updateBook, removeBook, clearLoadCorruption, clearSaveError, retrySave } =
     useBooks()
   const [filter, setFilter] = useState<BookFilterValue>('all')
   const [search, setSearch] = useState('')
@@ -103,6 +103,9 @@ export default function App() {
             onAdd={handleAdd}
             loadCorruption={loadCorruption}
             onDismissCorruption={clearLoadCorruption}
+            saveError={saveError}
+            onDismissSaveError={clearSaveError}
+            onRetrySave={retrySave}
           />
         ) : null}
         {showEdit ? (

--- a/src/index.css
+++ b/src/index.css
@@ -303,6 +303,28 @@ html[data-theme='dark'] .reading-banner {
   min-width: 0;
 }
 
+.reading-banner__link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.reading-banner__link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.reading-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.reading-banner__action {
+  flex-shrink: 0;
+}
+
 .reading-banner__close {
   flex-shrink: 0;
 }

--- a/src/reading/components/ReadingListPanel.tsx
+++ b/src/reading/components/ReadingListPanel.tsx
@@ -16,6 +16,9 @@ type ReadingListPanelProps = {
   onAdd: () => void
   loadCorruption: boolean
   onDismissCorruption: () => void
+  saveError: boolean
+  onDismissSaveError: () => void
+  onRetrySave: () => void
 }
 
 export function ReadingListPanel({
@@ -30,6 +33,9 @@ export function ReadingListPanel({
   onAdd,
   loadCorruption,
   onDismissCorruption,
+  saveError,
+  onDismissSaveError,
+  onRetrySave,
 }: ReadingListPanelProps) {
   const searchId = useId()
   const listId = useId()
@@ -48,6 +54,38 @@ export function ReadingListPanel({
           >
             閉じる
           </button>
+        </div>
+      ) : null}
+      {saveError ? (
+        <div className="reading-banner" role="alert">
+          <p className="reading-banner__text">
+            読書データの保存に失敗しました。プライベートブラウズや端末の空き容量、
+            <a
+              className="reading-banner__link"
+              href="https://developer.mozilla.org/ja/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria"
+              target="_blank"
+              rel="noreferrer"
+            >
+              ブラウザの保存クォータ（外部・MDN）
+            </a>
+            を確認してください。
+          </p>
+          <div className="reading-banner__actions">
+            <button
+              type="button"
+              className="button button--ghost reading-banner__action"
+              onClick={onRetrySave}
+            >
+              再試行
+            </button>
+            <button
+              type="button"
+              className="button button--ghost reading-banner__close"
+              onClick={onDismissSaveError}
+            >
+              閉じる
+            </button>
+          </div>
         </div>
       ) : null}
       <div className="reading-sidebar__header">

--- a/src/reading/hooks/useBooks.ts
+++ b/src/reading/hooks/useBooks.ts
@@ -26,6 +26,7 @@ export function useBooks() {
   const [loadCorruption, setLoadCorruption] = useState(
     () => initialLoad.hadCorruption,
   )
+  const [saveError, setSaveError] = useState(false)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
@@ -41,7 +42,8 @@ export function useBooks() {
       clearTimeout(saveTimerRef.current)
     }
     saveTimerRef.current = setTimeout(() => {
-      saveBooksToStorage(books)
+      const ok = saveBooksToStorage(books)
+      setSaveError(!ok)
       saveTimerRef.current = null
     }, SAVE_DEBOUNCE_MS)
     return () => {
@@ -96,12 +98,23 @@ export function useBooks() {
     setLoadCorruption(false)
   }, [])
 
+  const clearSaveError = useCallback(() => {
+    setSaveError(false)
+  }, [])
+
+  const retrySave = useCallback(() => {
+    setSaveError(!saveBooksToStorage(books))
+  }, [books])
+
   return {
     books,
     loadCorruption,
+    saveError,
     addBook,
     updateBook,
     removeBook,
     clearLoadCorruption,
+    clearSaveError,
+    retrySave,
   }
 }

--- a/src/reading/lib/booksStorage.ts
+++ b/src/reading/lib/booksStorage.ts
@@ -93,13 +93,15 @@ export function loadBooksFromStorage(): LoadBooksResult {
   }
 }
 
-export function saveBooksToStorage(books: Book[]) {
+export function saveBooksToStorage(books: Book[]): boolean {
   try {
     window.localStorage.setItem(READING_BOOKS_STORAGE_KEY, JSON.stringify(books))
+    return true
   } catch {
     console.warn(
       '読書データの保存に失敗しました。ブラウザの保存容量制限等をご確認ください。',
     )
+    return false
   }
 }
 


### PR DESCRIPTION
## 概要

`saveBooksToStorage` が失敗したときに、一覧上部へバナーを表示し、MDN への参考リンク・再試行・閉じるを用意しました。`useBooks` で保存結果を追跡します。

Closes #25

## 変更ファイルとその概要

```
src/
├── ✅ App.tsx — hook の新フィールドをパネルへ渡す
├── ✅ index.css — バナー内リンク・アクションボタン
├── reading/components/
│   └── ✅ ReadingListPanel.tsx — 保存エラーバナー
├── reading/hooks/
│   └── ✅ useBooks.ts — `saveError` / `retrySave` / `clearSaveError`
└── reading/lib/
    └── ✅ booksStorage.ts — 成否を boolean で返す
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功

## 関連 issue

close #25
