### PR TITLE
feat: [#27] 読了・読了日のカレンダー UI 選択

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.5",
+        "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.5"
       },
       "devDependencies": {
@@ -266,6 +267,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -815,6 +822,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1309,6 +1325,22 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2336,6 +2368,28 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "react": "^19.2.5",
+    "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {

--- a/src/index.css
+++ b/src/index.css
@@ -620,6 +620,89 @@ html[data-theme='dark'] .reading-banner {
   gap: 0.2rem;
 }
 
+.reading-form__date-field-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.reading-form__date-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.reading-form__input--date {
+  flex: 1;
+  min-width: 0;
+}
+
+.reading-form__calendar-trigger {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+}
+
+.date-picker-dialog {
+  padding: 0;
+  border: none;
+  max-width: calc(100vw - 1.5rem);
+  background: transparent;
+}
+
+.date-picker-dialog::backdrop {
+  background: rgba(20, 17, 24, 0.45);
+}
+
+html[data-theme='dark'] .date-picker-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='system'] .date-picker-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.55);
+  }
+}
+
+.date-picker-dialog__panel {
+  padding: 1rem 1.1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.date-picker-dialog__title {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  color: var(--text-heading);
+}
+
+.date-picker-dialog__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border);
+}
+
+.rdp-reading {
+  --rdp-accent-color: var(--accent);
+  --rdp-outside-opacity: 0.55;
+  margin: 0;
+}
+
+.rdp-reading .rdp-day_button {
+  border-radius: 6px;
+}
+
+.rdp-reading__caption {
+  color: var(--text-heading);
+  font-weight: 600;
+}
+
 .reading-form__body {
   resize: vertical;
   min-height: 10rem;

--- a/src/reading/components/BookDateField.tsx
+++ b/src/reading/components/BookDateField.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { DayPicker } from 'react-day-picker'
+import { ja } from 'date-fns/locale/ja'
+import 'react-day-picker/style.css'
+
+type BookDateFieldProps = {
+  id: string
+  label: string
+  value: string | null
+  onChange: (next: string | null) => void
+}
+
+function parseYmdToLocalDate(value: string | null | undefined): Date | undefined {
+  if (value == null || value === '' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return undefined
+  }
+  const [y, m, d] = value.split('-').map(Number)
+  return new Date(y, m - 1, d, 12, 0, 0, 0)
+}
+
+function toYmdLocal(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+export function BookDateField({ id, label, value, onChange }: BookDateFieldProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const dialogTitleId = useId()
+  const triggerId = useId()
+
+  useEffect(() => {
+    const el = dialogRef.current
+    if (!el) {
+      return
+    }
+    if (pickerOpen && !el.open) {
+      el.showModal()
+      return
+    }
+    if (!pickerOpen && el.open) {
+      el.close()
+    }
+  }, [pickerOpen])
+
+  useEffect(() => {
+    const el = dialogRef.current
+    if (!el) {
+      return
+    }
+    const onClose = () => setPickerOpen(false)
+    el.addEventListener('close', onClose)
+    return () => el.removeEventListener('close', onClose)
+  }, [])
+
+  const selected = parseYmdToLocalDate(value)
+
+  return (
+    <div className="reading-form__date-field-inner">
+      <label className="reading-form__label" htmlFor={id}>
+        {label}
+      </label>
+      <div className="reading-form__date-controls">
+        <input
+          id={id}
+          className="reading-form__input reading-form__input--date"
+          type="date"
+          name={id}
+          value={value ?? ''}
+          onChange={(e) => {
+            const v = e.target.value
+            onChange(v === '' ? null : v)
+          }}
+        />
+        <button
+          id={triggerId}
+          type="button"
+          className="button button--ghost reading-form__calendar-trigger"
+          onClick={() => setPickerOpen(true)}
+          aria-expanded={pickerOpen}
+          aria-haspopup="dialog"
+          aria-controls={`${id}-calendar-dialog`}
+        >
+          カレンダー
+        </button>
+      </div>
+      <dialog
+        id={`${id}-calendar-dialog`}
+        ref={dialogRef}
+        className="date-picker-dialog"
+        aria-labelledby={dialogTitleId}
+      >
+        <div className="date-picker-dialog__panel">
+          <h2 id={dialogTitleId} className="date-picker-dialog__title">
+            {label}を選択
+          </h2>
+          <DayPicker
+            mode="single"
+            selected={selected}
+            onSelect={(d) => {
+              if (d) {
+                onChange(toYmdLocal(d))
+              }
+              setPickerOpen(false)
+            }}
+            locale={ja}
+            defaultMonth={selected ?? new Date()}
+            classNames={{
+              root: 'rdp-reading',
+              month_caption: 'rdp-reading__caption',
+            }}
+          />
+          <div className="date-picker-dialog__footer">
+            <button
+              type="button"
+              className="button button--ghost"
+              onClick={() => {
+                onChange(null)
+                setPickerOpen(false)
+              }}
+            >
+              日付をクリア
+            </button>
+            <button
+              type="button"
+              className="button button--ghost"
+              onClick={() => setPickerOpen(false)}
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </div>
+  )
+}

--- a/src/reading/components/BookForm.tsx
+++ b/src/reading/components/BookForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { Book, BookStatus } from '../types/book'
 import { BOOK_STATUS_LABEL } from '../statusLabels'
+import { BookDateField } from './BookDateField'
 
 type BookFormProps = {
   book: Book | null
@@ -114,35 +115,19 @@ export function BookForm({
       </select>
       <div className="reading-form__row-dates">
         <p className="reading-form__date-field">
-          <label className="reading-form__label" htmlFor="book-started">
-            読み始めた日
-          </label>
-          <input
+          <BookDateField
             id="book-started"
-            className="reading-form__input"
-            type="date"
-            name="startedOn"
-            value={book.startedOn ?? ''}
-            onChange={(e) => {
-              const v = e.target.value
-              onPatch(id, { startedOn: v === '' ? null : v })
-            }}
+            label="読み始めた日"
+            value={book.startedOn}
+            onChange={(next) => onPatch(id, { startedOn: next })}
           />
         </p>
         <p className="reading-form__date-field">
-          <label className="reading-form__label" htmlFor="book-finished">
-            読了日
-          </label>
-          <input
+          <BookDateField
             id="book-finished"
-            className="reading-form__input"
-            type="date"
-            name="finishedOn"
-            value={book.finishedOn ?? ''}
-            onChange={(e) => {
-              const v = e.target.value
-              onPatch(id, { finishedOn: v === '' ? null : v })
-            }}
+            label="読了日"
+            value={book.finishedOn}
+            onChange={(next) => onPatch(id, { finishedOn: next })}
           />
         </p>
       </div>


### PR DESCRIPTION
## 概要

読み始めた日・読了日について、従来の `type="date"` に加え「カレンダー」から `react-day-picker` の月送り UI で選べるようにしました（`YYYY-MM-DD` のまま）。ダイアログから日付クリア・閉じる・日本語ロケール表示に対応しています。

Closes #27

## 変更ファイルとその概要

```
├── ✅ package.json / package-lock.json
│   - react-day-picker 依存
├── src/index.css
│   - 日付行レイアウト・カレンダーダイアログ・rdp 上書き
└── src/reading/components/
    ├── ✅ BookDateField.tsx（新規）
    └── ✅ BookForm.tsx
```

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功
- 手動: ネイティブ日付入力とカレンダーの双方で値が整合すること

## 関連 issue

close #27
