### PR TITLE
feat: [#28] 読書リマインド通知（時刻設定・Notification）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { BookForm } from './reading/components/BookForm'
 import { ReadingListPanel } from './reading/components/ReadingListPanel'
 import { ThemeToggle } from './reading/components/ThemeToggle'
+import { ReadingReminderSettings } from './reading/components/ReadingReminderSettings'
 import { useBooks } from './reading/hooks/useBooks'
 import { filterBooks, type BookFilterValue } from './reading/lib/filterBooks'
 
@@ -81,6 +82,7 @@ export default function App() {
   return (
     <div className="app">
       <div className="app__topbar">
+        <ReadingReminderSettings />
         <ThemeToggle />
       </div>
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -94,6 +94,7 @@ body {
   justify-content: flex-end;
   gap: 0.75rem;
   padding: 0 0 0.65rem;
+  flex-wrap: wrap;
 }
 
 .app__theme-fieldset {
@@ -625,4 +626,99 @@ html[data-theme='dark'] .reading-banner {
   min-height: 10rem;
   line-height: 1.45;
   font-size: 0.95rem;
+}
+
+.reminder-settings-trigger {
+  font-size: 0.85rem;
+}
+
+.reminder-dialog {
+  padding: 0;
+  border: none;
+  max-width: calc(100vw - 1.5rem);
+  background: transparent;
+}
+
+.reminder-dialog::backdrop {
+  background: rgba(20, 17, 24, 0.45);
+}
+
+html[data-theme='dark'] .reminder-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme='system'] .reminder-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.55);
+  }
+}
+
+.reminder-dialog__panel {
+  padding: 1rem 1.15rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  max-width: 22rem;
+}
+
+.reminder-dialog__title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--text-heading);
+}
+
+.reminder-dialog__note {
+  margin: 0 0 0.65rem;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.reminder-dialog__permission {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.reminder-dialog__actions {
+  margin: 0 0 0.75rem;
+}
+
+.reminder-dialog__check {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.reminder-dialog__time-row {
+  margin: 0 0 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.reminder-dialog__time-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.reminder-dialog__time-input {
+  font: inherit;
+  color: var(--text-heading);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 0.45rem 0.6rem;
+}
+
+.reminder-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
 }

--- a/src/reading/components/ReadingReminderSettings.tsx
+++ b/src/reading/components/ReadingReminderSettings.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useReadingReminder } from '../hooks/useReadingReminder'
+import {
+  loadReminderSettings,
+  parseHmFromTimeInput,
+  saveReminderSettings,
+  timeToHmString,
+  type ReadingReminderSettings,
+} from '../lib/readingReminderStorage'
+
+function permissionLabel(permission: NotificationPermission) {
+  switch (permission) {
+    case 'granted':
+      return '許可済み'
+    case 'denied':
+      return '拒否されています（ブラウザ設定から変更できます）'
+    default:
+      return '未許可'
+  }
+}
+
+export function ReadingReminderSettings() {
+  const initial = useMemo(() => loadReminderSettings(), [])
+  const [settings, setSettings] = useState<ReadingReminderSettings>(initial)
+  const [timeStr, setTimeStr] = useState(() =>
+    timeToHmString(initial.hour, initial.minute),
+  )
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [permState, setPermState] = useState<NotificationPermission>(() =>
+    typeof Notification !== 'undefined' ? Notification.permission : 'denied',
+  )
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const titleId = useId()
+
+  useReadingReminder(settings)
+
+  useEffect(() => {
+    saveReminderSettings(settings)
+  }, [settings])
+
+  useEffect(() => {
+    const el = dialogRef.current
+    if (!el) {
+      return
+    }
+    if (dialogOpen && !el.open) {
+      el.showModal()
+      return
+    }
+    if (!dialogOpen && el.open) {
+      el.close()
+    }
+  }, [dialogOpen])
+
+  useEffect(() => {
+    const el = dialogRef.current
+    if (!el) {
+      return
+    }
+    const onClose = () => setDialogOpen(false)
+    el.addEventListener('close', onClose)
+    return () => el.removeEventListener('close', onClose)
+  }, [])
+
+  const requestNotifyPermission = async () => {
+    if (typeof Notification === 'undefined' || !Notification.requestPermission) {
+      return
+    }
+    const p = await Notification.requestPermission()
+    setPermState(p)
+    if (p !== 'granted') {
+      setSettings((s) => ({ ...s, enabled: false }))
+    }
+  }
+
+  const applyTimeStr = (raw: string) => {
+    const parsed = parseHmFromTimeInput(raw)
+    if (!parsed) {
+      return
+    }
+    setTimeStr(timeToHmString(parsed.hour, parsed.minute))
+    setSettings((s) => ({ ...s, hour: parsed.hour, minute: parsed.minute }))
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="button button--ghost reminder-settings-trigger"
+        onClick={() => setDialogOpen(true)}
+      >
+        リマインド
+      </button>
+      <dialog
+        ref={dialogRef}
+        className="reminder-dialog"
+        aria-labelledby={titleId}
+      >
+        <div className="reminder-dialog__panel">
+          <h2 id={titleId} className="reminder-dialog__title">
+            読書リマインド（通知）
+          </h2>
+          <p className="reminder-dialog__note">
+            ブラウザの通知 API を使います。アプリを閉じていても OS／ブラウザの制限により届かない場合があります（特に
+            iOS Safari など）。
+          </p>
+          <p className="reminder-dialog__permission">
+            通知の権限: <strong>{permissionLabel(permState)}</strong>
+          </p>
+          {permState !== 'granted' ? (
+            <p className="reminder-dialog__actions">
+              <button
+                type="button"
+                className="button button--primary"
+                onClick={() => void requestNotifyPermission()}
+              >
+                通知を許可する
+              </button>
+            </p>
+          ) : null}
+          <label className="reminder-dialog__check">
+            <input
+              type="checkbox"
+              checked={settings.enabled}
+              disabled={permState !== 'granted'}
+              onChange={(e) => {
+                const on = e.target.checked
+                setSettings((s) => ({ ...s, enabled: on && permState === 'granted' }))
+              }}
+            />
+            毎日この時刻に通知する
+          </label>
+          <p className="reminder-dialog__time-row">
+            <label className="reminder-dialog__time-label" htmlFor="reading-reminder-time">
+              時刻
+            </label>
+            <input
+              id="reading-reminder-time"
+              type="time"
+              className="reminder-dialog__time-input"
+              value={timeStr}
+              onChange={(e) => {
+                const v = e.target.value
+                setTimeStr(v)
+                applyTimeStr(v)
+              }}
+            />
+          </p>
+          <div className="reminder-dialog__footer">
+            <button
+              type="button"
+              className="button button--ghost"
+              onClick={() => setDialogOpen(false)}
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </>
+  )
+}

--- a/src/reading/hooks/useReadingReminder.ts
+++ b/src/reading/hooks/useReadingReminder.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+
+type UseReadingReminderOptions = {
+  enabled: boolean
+  hour: number
+  minute: number
+}
+
+/**
+ * 指定時刻に 1 回だけブラウザ通知を試みる（権限が granted のときのみ）。
+ * 同一分の重複通知を避けるため、分単位のキーで抑止する。
+ */
+export function useReadingReminder({ enabled, hour, minute }: UseReadingReminderOptions) {
+  const firedMinuteKeyRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!enabled || typeof Notification === 'undefined') {
+      return
+    }
+    if (Notification.permission !== 'granted') {
+      return
+    }
+
+    const tick = () => {
+      const now = new Date()
+      if (now.getHours() !== hour || now.getMinutes() !== minute) {
+        return
+      }
+      const minuteKey = `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}-${hour}-${minute}`
+      if (firedMinuteKeyRef.current === minuteKey) {
+        return
+      }
+      firedMinuteKeyRef.current = minuteKey
+      try {
+        new Notification('読書の時間です', {
+          body: '今日の読書を記録してみましょう。',
+          lang: 'ja',
+        })
+      } catch {
+        // 環境によっては Notification コンストラクタが失敗する
+      }
+    }
+
+    const id = window.setInterval(tick, 15_000)
+    tick()
+    return () => window.clearInterval(id)
+  }, [enabled, hour, minute])
+}

--- a/src/reading/lib/readingReminderStorage.ts
+++ b/src/reading/lib/readingReminderStorage.ts
@@ -1,0 +1,95 @@
+const REMINDER_STORAGE_KEY = 'reading-journal:reminder' as const
+
+export type ReadingReminderSettings = {
+  enabled: boolean
+  hour: number
+  minute: number
+}
+
+const DEFAULTS: ReadingReminderSettings = {
+  enabled: false,
+  hour: 21,
+  minute: 0,
+}
+
+function clampHour(n: number) {
+  return Math.min(23, Math.max(0, Math.floor(n)))
+}
+
+function clampMinute(n: number) {
+  return Math.min(59, Math.max(0, Math.floor(n)))
+}
+
+function isSettings(o: unknown): o is ReadingReminderSettings {
+  if (o === null || typeof o !== 'object') {
+    return false
+  }
+  const r = o as Record<string, unknown>
+  return (
+    typeof r.enabled === 'boolean' &&
+    typeof r.hour === 'number' &&
+    typeof r.minute === 'number' &&
+    Number.isFinite(r.hour) &&
+    Number.isFinite(r.minute)
+  )
+}
+
+export function loadReminderSettings(): ReadingReminderSettings {
+  if (typeof window === 'undefined') {
+    return { ...DEFAULTS }
+  }
+  try {
+    const raw = window.localStorage.getItem(REMINDER_STORAGE_KEY)
+    if (!raw) {
+      return { ...DEFAULTS }
+    }
+    const parsed: unknown = JSON.parse(raw)
+    if (!isSettings(parsed)) {
+      return { ...DEFAULTS }
+    }
+    return {
+      enabled: parsed.enabled,
+      hour: clampHour(parsed.hour),
+      minute: clampMinute(parsed.minute),
+    }
+  } catch {
+    return { ...DEFAULTS }
+  }
+}
+
+export function saveReminderSettings(settings: ReadingReminderSettings) {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(
+      REMINDER_STORAGE_KEY,
+      JSON.stringify({
+        enabled: settings.enabled,
+        hour: clampHour(settings.hour),
+        minute: clampMinute(settings.minute),
+      }),
+    )
+  } catch {
+    // 補助機能のため保存失敗は握りつぶす
+  }
+}
+
+export function timeToHmString(hour: number, minute: number) {
+  const h = String(clampHour(hour)).padStart(2, '0')
+  const m = String(clampMinute(minute)).padStart(2, '0')
+  return `${h}:${m}`
+}
+
+export function parseHmFromTimeInput(value: string): { hour: number; minute: number } | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim())
+  if (!match) {
+    return null
+  }
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+    return null
+  }
+  return { hour: clampHour(hour), minute: clampMinute(minute) }
+}


### PR DESCRIPTION
## 概要

読書リマインドを設定できるようにしました。通知権限のリクエスト、毎日の時刻指定、localStorage への保存、指定分に 1 回の Notification（権限 granted 時）に対応しています。iOS Safari 等の制限はダイアログ内に記載しています。

Closes #28

## 変更ファイルとその概要

- `App.tsx` / `index.css`
- `ReadingReminderSettings.tsx` / `useReadingReminder.ts` / `readingReminderStorage.ts`

## 関連 issue

close #28
