### PR TITLE
feat: [#29] 読了本に基づくおすすめ候補（Open Library）

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -626,3 +626,58 @@ html[data-theme='dark'] .reading-banner {
   line-height: 1.45;
   font-size: 0.95rem;
 }
+
+.reading-suggestions {
+  margin: 0;
+  padding: 0.65rem 1rem 1rem;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.reading-suggestions__title {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-heading);
+}
+
+.reading-suggestions__disclaimer {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.reading-suggestions__status {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.reading-suggestions__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reading-suggestions__item {
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: var(--text);
+}
+
+.reading-suggestions__book-title {
+  display: block;
+  font-weight: 600;
+  color: var(--text-heading);
+}
+
+.reading-suggestions__reason {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}

--- a/src/reading/components/BookSuggestionsPanel.tsx
+++ b/src/reading/components/BookSuggestionsPanel.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import type { Book } from '../types/book'
+import {
+  fetchFinishedBookSuggestions,
+  type BookSuggestion,
+} from '../lib/fetchBookSuggestions'
+
+type BookSuggestionsPanelProps = {
+  books: Book[]
+}
+
+export function BookSuggestionsPanel({ books }: BookSuggestionsPanelProps) {
+  const [items, setItems] = useState<BookSuggestion[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const hasFinished = books.some((b) => b.status === 'finished' && b.title.trim().length > 0)
+
+  useEffect(() => {
+    if (!hasFinished) {
+      return
+    }
+    let cancelled = false
+    const t = window.setTimeout(() => {
+      setLoading(true)
+      void fetchFinishedBookSuggestions(books, 5).then((suggestions) => {
+        if (cancelled) {
+          return
+        }
+        setLoading(false)
+        setItems(suggestions)
+      })
+    }, 400)
+    return () => {
+      cancelled = true
+      window.clearTimeout(t)
+    }
+  }, [books, hasFinished])
+
+  if (!hasFinished) {
+    return null
+  }
+
+  return (
+    <section className="reading-suggestions" aria-label="読了に基づくおすすめ（参考）">
+      <h2 className="reading-suggestions__title">おすすめ（参考）</h2>
+      <p className="reading-suggestions__disclaimer">
+        Open Library の検索結果です。実在や版の一致は保証されません。
+      </p>
+      {loading ? (
+        <p className="reading-suggestions__status">読み込み中…</p>
+      ) : items.length === 0 ? (
+        <p className="reading-suggestions__status">
+          候補を取得できませんでした。通信状況を確認するか、しばらくしてから再度お試しください。
+        </p>
+      ) : (
+        <ol className="reading-suggestions__list">
+          {items.map((s, index) => (
+            <li key={`${s.key}-${index}`} className="reading-suggestions__item">
+              <span className="reading-suggestions__book-title">{s.title}</span>
+              <span className="reading-suggestions__reason">{s.reason}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}

--- a/src/reading/components/ReadingListPanel.tsx
+++ b/src/reading/components/ReadingListPanel.tsx
@@ -3,6 +3,7 @@ import type { Book } from '../types/book'
 import type { BookFilterValue } from '../lib/filterBooks'
 import { BookFilterBar } from './BookFilterBar'
 import { BookListRow } from './BookListRow'
+import { BookSuggestionsPanel } from './BookSuggestionsPanel'
 
 type ReadingListPanelProps = {
   books: Book[]
@@ -84,6 +85,7 @@ export function ReadingListPanel({
           ))}
         </ul>
       )}
+      <BookSuggestionsPanel books={books} />
     </aside>
   )
 }

--- a/src/reading/lib/fetchBookSuggestions.ts
+++ b/src/reading/lib/fetchBookSuggestions.ts
@@ -1,0 +1,97 @@
+import type { Book } from '../types/book'
+
+export type BookSuggestion = {
+  key: string
+  title: string
+  reason: string
+}
+
+type OpenLibrarySearchDoc = {
+  title?: string | string[]
+  key?: string
+}
+
+function titleFromDoc(doc: OpenLibrarySearchDoc): string {
+  const t = doc.title
+  if (typeof t === 'string') {
+    return t.trim()
+  }
+  if (Array.isArray(t) && typeof t[0] === 'string') {
+    return t[0].trim()
+  }
+  return ''
+}
+
+type OpenLibrarySearchResponse = {
+  docs?: OpenLibrarySearchDoc[]
+}
+
+function normalizeTitle(t: string) {
+  return t.trim().toLowerCase()
+}
+
+function tokenizeForQuery(title: string): string[] {
+  const parts = title
+    .split(/[\s\u3000、,，・/:：-]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= 2)
+  return parts.length > 0 ? parts : [title.trim()].filter((s) => s.length > 0)
+}
+
+function buildExcludeSet(books: Book[]) {
+  return new Set(books.map((b) => normalizeTitle(b.title)).filter((t) => t.length > 0))
+}
+
+/**
+ * 読了本のタイトルを種に Open Library の検索 API で候補を取得する（クライアント完結・オプトインなし）。
+ * ネットワークエラー時は空配列。
+ */
+export async function fetchFinishedBookSuggestions(
+  books: Book[],
+  max = 5,
+): Promise<BookSuggestion[]> {
+  const finished = books.filter((b) => b.status === 'finished' && b.title.trim().length > 0)
+  if (finished.length === 0) {
+    return []
+  }
+  const seed = finished[0]
+  const tokens = tokenizeForQuery(seed.title)
+  const q = tokens[0] ?? seed.title.trim()
+  const exclude = buildExcludeSet(books)
+
+  try {
+    const url = `https://openlibrary.org/search.json?limit=12&q=${encodeURIComponent(q)}`
+    const res = await fetch(url)
+    if (!res.ok) {
+      return []
+    }
+    const json = (await res.json()) as OpenLibrarySearchResponse
+    const docs = Array.isArray(json.docs) ? json.docs : []
+    const out: BookSuggestion[] = []
+    for (const doc of docs) {
+      const title = titleFromDoc(doc)
+      if (!title) {
+        continue
+      }
+      const n = normalizeTitle(title)
+      if (exclude.has(n)) {
+        continue
+      }
+      const key =
+        typeof doc.key === 'string' && doc.key.length > 0
+          ? doc.key
+          : `title:${n}`
+      out.push({
+        key,
+        title,
+        reason: `読了「${seed.title.trim()}」に関連する検索結果（Open Library・参考）`,
+      })
+      if (out.length >= max) {
+        break
+      }
+    }
+    return out
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## 概要

読了ステータスでタイトルがある本を手がかりに、[Open Library](https://openlibrary.org/) の検索 API で最大 5 件の候補を一覧パネル下部に表示します。登録済みタイトルは除外し、根拠は候補ごとに短文で示します。外部送信であることと「参考」であることを UI に明記しています。

Closes #29

## 変更ファイルとその概要

- `src/reading/lib/fetchBookSuggestions.ts`（新規）— 検索・正規化・除外
- `src/reading/components/BookSuggestionsPanel.tsx`（新規）— 表示・デバウンス取得
- `src/reading/components/ReadingListPanel.tsx` — パネル組み込み
- `src/index.css` — おすすめブロックのスタイル

## テスト内容（参考までに）

- `npm run build` / `npm run lint` 成功

## 関連 issue

close #29
